### PR TITLE
feat: add HTML to HSML converter with WASM support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,8 +448,10 @@ version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "html5ever",
  "ignore",
  "js-sys",
+ "markup5ever_rcdom",
  "nom",
  "nom_locate",
  "predicates",
@@ -461,6 +463,16 @@ dependencies = [
  "tower-lsp",
  "wasm-bindgen",
  "wasm-bindgen-test",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -689,6 +701,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.38.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +738,12 @@ dependencies = [
  "cc",
  "walkdir",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -768,6 +809,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +836,45 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -820,6 +910,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
@@ -1035,6 +1131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1153,31 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "strsim"
@@ -1091,6 +1218,16 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
 ]
 
 [[package]]
@@ -1246,6 +1383,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -1425,6 +1568,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1696,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xml5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
+dependencies = [
+ "log",
+ "markup5ever",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ crate-type = ["cdylib", "rlib"]
 nom = "8.0.0"
 nom_locate = "5.0.0"
 serde = { version = "1.0.228", features = ["derive"] }
+html5ever = "0.38"
+markup5ever_rcdom = "0.38"
 serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.149"
 wasm-bindgen = "0.2.117"

--- a/src/converter/emitter.rs
+++ b/src/converter/emitter.rs
@@ -145,7 +145,7 @@ fn has_mixed_content(node: &Handle) -> bool {
 fn serialize_inner_html(node: &Handle) -> String {
     let mut html = String::new();
     for child in &effective_children(node) {
-        serialize_node_to_html(child, &mut html);
+        serialize_node_to_html(child, &mut html, false);
     }
     html
 }
@@ -206,13 +206,18 @@ fn escape_hsml_attr(key: &str, value: &str) -> String {
     }
 }
 
-fn serialize_node_to_html(node: &Handle, output: &mut String) {
+fn serialize_node_to_html(node: &Handle, output: &mut String, in_raw_text: bool) {
     match &node.data {
         NodeData::Text { contents } => {
-            output.push_str(&escape_html_text(&contents.borrow()));
+            if in_raw_text {
+                output.push_str(&contents.borrow());
+            } else {
+                output.push_str(&escape_html_text(&contents.borrow()));
+            }
         }
         NodeData::Element { name, attrs, .. } => {
             let tag = name.local.as_ref();
+            let is_raw = matches!(tag, "script" | "style");
             output.push('<');
             output.push_str(tag);
             for attr in attrs.borrow().iter() {
@@ -227,7 +232,7 @@ fn serialize_node_to_html(node: &Handle, output: &mut String) {
             } else {
                 output.push('>');
                 for child in &effective_children(node) {
-                    serialize_node_to_html(child, output);
+                    serialize_node_to_html(child, output, is_raw);
                 }
                 output.push_str("</");
                 output.push_str(tag);

--- a/src/converter/emitter.rs
+++ b/src/converter/emitter.rs
@@ -209,7 +209,9 @@ fn emit_node(node: &Handle, depth: usize, output: &mut String) {
         NodeData::Comment { contents } => {
             let indent = " ".repeat(depth * INDENT_SIZE);
             let text = contents.trim();
-            output.push_str(&format!("{indent}//! {text}\n"));
+            for line in text.lines() {
+                output.push_str(&format!("{indent}//! {line}\n"));
+            }
         }
         NodeData::Text { .. } => {
             // Standalone text nodes outside elements are ignored.

--- a/src/converter/emitter.rs
+++ b/src/converter/emitter.rs
@@ -135,6 +135,21 @@ fn escape_html_attr(text: &str) -> String {
         .replace('>', "&gt;")
 }
 
+/// Check if a value contains `#` or `.` outside of `[...]` brackets.
+/// TailwindCSS uses `[#hex]` and `[...]` which are safe for shorthand syntax.
+fn has_selector_chars_outside_brackets(value: &str) -> bool {
+    let mut in_bracket = false;
+    for ch in value.chars() {
+        match ch {
+            '[' => in_bracket = true,
+            ']' => in_bracket = false,
+            '#' | '.' if !in_bracket => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
 /// Check if an attribute key is a framework directive (Vue/Angular)
 /// whose value contains a JavaScript expression rather than a plain HTML value.
 fn is_framework_directive(key: &str) -> bool {
@@ -233,14 +248,32 @@ fn emit_element(
     // Extract id and class from attributes
     let mut id: Option<&str> = None;
     let mut classes: Vec<&str> = Vec::new();
+    let mut unsafe_class_attr: Option<String> = None;
     let mut other_attrs: Vec<(&str, &StrTendril)> = Vec::new();
 
     for attr in attrs {
         let key = attr.name.local.as_ref();
         match key {
-            "id" => id = Some(&attr.value),
+            "id" => {
+                let val = &*attr.value;
+                if has_selector_chars_outside_brackets(val) {
+                    other_attrs.push((key, &attr.value));
+                } else {
+                    id = Some(val);
+                }
+            }
             "class" => {
-                classes.extend(attr.value.split_whitespace());
+                let mut unsafe_classes: Vec<&str> = Vec::new();
+                for class in attr.value.split_whitespace() {
+                    if has_selector_chars_outside_brackets(class) {
+                        unsafe_classes.push(class);
+                    } else {
+                        classes.push(class);
+                    }
+                }
+                if !unsafe_classes.is_empty() {
+                    unsafe_class_attr = Some(unsafe_classes.join(" "));
+                }
             }
             _ => {
                 other_attrs.push((key, &attr.value));
@@ -270,10 +303,21 @@ fn emit_element(
     }
 
     // Append (attributes)
-    if !other_attrs.is_empty() {
+    let has_attrs = !other_attrs.is_empty() || unsafe_class_attr.is_some();
+    if has_attrs {
         line.push('(');
-        for (i, (key, value)) in other_attrs.iter().enumerate() {
-            if i > 0 {
+        let mut first = true;
+
+        // Unsafe classes that couldn't use shorthand syntax
+        if let Some(ref unsafe_classes) = unsafe_class_attr {
+            line.push_str("class=\"");
+            line.push_str(&escape_hsml_attr("class", unsafe_classes));
+            line.push('"');
+            first = false;
+        }
+
+        for (key, value) in other_attrs.iter() {
+            if !first {
                 line.push_str(", ");
             }
             if value.is_empty() {
@@ -285,6 +329,7 @@ fn emit_element(
                 line.push_str(&escape_hsml_attr(key, value));
                 line.push('"');
             }
+            first = false;
         }
         line.push(')');
     }

--- a/src/converter/emitter.rs
+++ b/src/converter/emitter.rs
@@ -127,12 +127,38 @@ fn escape_html_text(text: &str) -> String {
         .replace('>', "&gt;")
 }
 
-/// Escape special HTML characters in attribute values.
+/// Escape special HTML characters in attribute values (for HTML serialization).
 fn escape_html_attr(text: &str) -> String {
     text.replace('&', "&amp;")
         .replace('"', "&quot;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
+}
+
+/// Check if an attribute key is a framework directive (Vue/Angular)
+/// whose value contains a JavaScript expression rather than a plain HTML value.
+fn is_framework_directive(key: &str) -> bool {
+    key.starts_with(':')
+        || key.starts_with('@')
+        || key.starts_with("v-")
+        || key.starts_with('#')
+        || key.starts_with('[')
+        || key.starts_with('(')
+        || key.starts_with('*')
+}
+
+/// Escape an HSML attribute value.
+/// Framework directives (Vue `:`, `@`, `v-`, `#`; Angular `[`, `(`, `*`)
+/// contain JavaScript expressions where `&` is valid (e.g. `&&`).
+/// Regular HTML attributes contain values where `&` must be `&amp;`
+/// so the compiled HTML is valid.
+fn escape_hsml_attr(key: &str, value: &str) -> String {
+    if is_framework_directive(key) {
+        value.replace('"', "&quot;")
+    } else {
+        // Encode & first, then " — order matters to avoid double-encoding
+        value.replace('&', "&amp;").replace('"', "&quot;")
+    }
 }
 
 fn serialize_node_to_html(node: &Handle, output: &mut String) {
@@ -259,7 +285,7 @@ fn emit_element(
             } else {
                 line.push_str(key);
                 line.push_str("=\"");
-                line.push_str(value);
+                line.push_str(&escape_hsml_attr(key, value));
                 line.push('"');
             }
         }

--- a/src/converter/emitter.rs
+++ b/src/converter/emitter.rs
@@ -6,15 +6,16 @@ use crate::common::is_void_element;
 const INDENT_SIZE: usize = 2;
 
 /// Emit HSML source from an html5ever DOM.
-pub fn emit(dom: &RcDom) -> String {
+pub fn emit(dom: &RcDom, original_html: &str) -> String {
     let mut output = String::new();
+    let lower_html = original_html.to_ascii_lowercase();
 
     // html5ever wraps content in <html><head><body> for document parsing.
     // We need to find the meaningful content nodes.
-    let nodes = find_content_nodes(&dom.document);
+    let nodes = find_content_nodes(&dom.document, &lower_html);
 
     for node in &nodes {
-        emit_node(node, 0, &mut output);
+        emit_node(node, 0, &lower_html, &mut output);
     }
 
     if !output.is_empty() && !output.ends_with('\n') {
@@ -26,7 +27,7 @@ pub fn emit(dom: &RcDom) -> String {
 
 /// Find the content nodes, skipping the implicit html/head/body wrapper
 /// that html5ever adds for document parsing.
-fn find_content_nodes(document: &Handle) -> Vec<Handle> {
+fn find_content_nodes(document: &Handle, lower_html: &str) -> Vec<Handle> {
     let children = document.children.borrow();
 
     // Check if this looks like a full document (has DOCTYPE or html element)
@@ -38,11 +39,19 @@ fn find_content_nodes(document: &Handle) -> Vec<Handle> {
         |c| matches!(&c.data, NodeData::Element { name, .. } if name.local.as_ref() == "html"),
     );
 
-    if has_doctype {
-        // Full document — emit doctype + html element
-        children.iter().cloned().collect()
+    // Check if the user explicitly wrote <html> or <body> tags
+    let has_explicit_html = lower_html.contains("<html") || lower_html.contains("<body");
+
+    if has_doctype || has_explicit_html {
+        // Full document or user-authored html/body — emit all children,
+        // but skip empty elements synthesized by html5ever that the user didn't write
+        children
+            .iter()
+            .filter(|c| !is_synthesized_empty_element(c, lower_html))
+            .cloned()
+            .collect()
     } else if let Some(html) = html_node {
-        // html5ever wrapped a fragment in <html><head><body>
+        // html5ever synthesized <html><head><body> for a fragment
         // Collect document-level comments + head elements + body children
         let mut nodes: Vec<Handle> = Vec::new();
 
@@ -81,6 +90,27 @@ fn find_content_nodes(document: &Handle) -> Vec<Handle> {
     } else {
         children.iter().cloned().collect()
     }
+}
+
+/// Check if a node is an empty element synthesized by html5ever
+/// that doesn't appear in the original HTML source.
+fn is_synthesized_empty_element(node: &Handle, lower_html: &str) -> bool {
+    if let NodeData::Element { name, .. } = &node.data {
+        let tag = name.local.as_ref();
+        let tag_in_source = lower_html.contains(&format!("<{tag}"));
+        if !tag_in_source {
+            let children = node.children.borrow();
+            // Empty or only contains whitespace text nodes
+            return children.iter().all(|c| {
+                if let NodeData::Text { contents } = &c.data {
+                    contents.borrow().trim().is_empty()
+                } else {
+                    false
+                }
+            });
+        }
+    }
+    false
 }
 
 /// Get the effective children of a node (handles template_contents).
@@ -213,13 +243,20 @@ fn serialize_node_to_html(node: &Handle, output: &mut String) {
     }
 }
 
-fn emit_node(node: &Handle, depth: usize, output: &mut String) {
+fn emit_node(node: &Handle, depth: usize, lower_html: &str, output: &mut String) {
     match &node.data {
         NodeData::Doctype { name, .. } => {
             output.push_str(&format!("doctype {name}\n"));
         }
         NodeData::Element { name, attrs, .. } => {
-            emit_element(node, &name.local, &attrs.borrow(), depth, output);
+            emit_element(
+                node,
+                &name.local,
+                &attrs.borrow(),
+                depth,
+                lower_html,
+                output,
+            );
         }
         NodeData::Comment { contents } => {
             let indent = " ".repeat(depth * INDENT_SIZE);
@@ -241,6 +278,7 @@ fn emit_element(
     tag: &str,
     attrs: &[html5ever::interface::Attribute],
     depth: usize,
+    lower_html: &str,
     output: &mut String,
 ) {
     let indent = " ".repeat(depth * INDENT_SIZE);
@@ -363,16 +401,26 @@ fn emit_element(
 
     // Whitespace-sensitive tags: preserve content exactly as text block
     if whitespace_sensitive {
-        let raw: String = significant_children
+        let has_non_text = significant_children
             .iter()
-            .filter_map(|c| {
-                if let NodeData::Text { contents } = &c.data {
-                    Some(contents.borrow().to_string())
-                } else {
-                    None
-                }
-            })
-            .collect();
+            .any(|c| !matches!(c.data, NodeData::Text { .. }));
+
+        let raw = if has_non_text {
+            // Has nested elements/comments — serialize as raw HTML to preserve markup
+            serialize_inner_html(node)
+        } else {
+            // Text-only — collect raw text content
+            significant_children
+                .iter()
+                .filter_map(|c| {
+                    if let NodeData::Text { contents } = &c.data {
+                        Some(contents.borrow().to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
 
         output.push_str(&format!("{indent}{line}.\n"));
         let text_indent = " ".repeat((depth + 1) * INDENT_SIZE);
@@ -434,7 +482,9 @@ fn emit_element(
 
     // Element children only — recurse
     output.push_str(&format!("{indent}{line}\n"));
-    for child in &significant_children {
-        emit_node(child, depth + 1, output);
+    for child in significant_children {
+        if !is_synthesized_empty_element(child, lower_html) {
+            emit_node(child, depth + 1, lower_html, output);
+        }
     }
 }

--- a/src/converter/emitter.rs
+++ b/src/converter/emitter.rs
@@ -120,10 +120,25 @@ fn serialize_inner_html(node: &Handle) -> String {
     html
 }
 
+/// Escape special HTML characters in text content.
+fn escape_html_text(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Escape special HTML characters in attribute values.
+fn escape_html_attr(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
 fn serialize_node_to_html(node: &Handle, output: &mut String) {
     match &node.data {
         NodeData::Text { contents } => {
-            output.push_str(&contents.borrow());
+            output.push_str(&escape_html_text(&contents.borrow()));
         }
         NodeData::Element { name, attrs, .. } => {
             let tag = name.local.as_ref();
@@ -133,7 +148,7 @@ fn serialize_node_to_html(node: &Handle, output: &mut String) {
                 output.push(' ');
                 output.push_str(attr.name.local.as_ref());
                 output.push_str("=\"");
-                output.push_str(&attr.value);
+                output.push_str(&escape_html_attr(&attr.value));
                 output.push('"');
             }
             if is_void_element(tag) {

--- a/src/converter/emitter.rs
+++ b/src/converter/emitter.rs
@@ -1,0 +1,332 @@
+use html5ever::tendril::StrTendril;
+use markup5ever_rcdom::{Handle, NodeData, RcDom};
+
+use crate::common::is_void_element;
+
+const INDENT_SIZE: usize = 2;
+
+/// Emit HSML source from an html5ever DOM.
+pub fn emit(dom: &RcDom) -> String {
+    let mut output = String::new();
+
+    // html5ever wraps content in <html><head><body> for document parsing.
+    // We need to find the meaningful content nodes.
+    let nodes = find_content_nodes(&dom.document);
+
+    for node in &nodes {
+        emit_node(node, 0, &mut output);
+    }
+
+    if !output.is_empty() && !output.ends_with('\n') {
+        output.push('\n');
+    }
+
+    output
+}
+
+/// Find the content nodes, skipping the implicit html/head/body wrapper
+/// that html5ever adds for document parsing.
+fn find_content_nodes(document: &Handle) -> Vec<Handle> {
+    let children = document.children.borrow();
+
+    // Check if this looks like a full document (has DOCTYPE or html element)
+    let has_doctype = children
+        .iter()
+        .any(|c| matches!(c.data, NodeData::Doctype { .. }));
+
+    let html_node = children.iter().find(
+        |c| matches!(&c.data, NodeData::Element { name, .. } if name.local.as_ref() == "html"),
+    );
+
+    if has_doctype {
+        // Full document — emit doctype + html element
+        children.iter().cloned().collect()
+    } else if let Some(html) = html_node {
+        // html5ever wrapped a fragment in <html><head><body>
+        // Collect document-level comments + head elements + body children
+        let mut nodes: Vec<Handle> = Vec::new();
+
+        // Collect document-level comments
+        for child in children.iter() {
+            if matches!(child.data, NodeData::Comment { .. }) {
+                nodes.push(child.clone());
+            }
+        }
+
+        let html_children = html.children.borrow();
+        let head = html_children.iter().find(
+            |c| matches!(&c.data, NodeData::Element { name, .. } if name.local.as_ref() == "head"),
+        );
+        let body = html_children.iter().find(
+            |c| matches!(&c.data, NodeData::Element { name, .. } if name.local.as_ref() == "body"),
+        );
+
+        // Head may contain elements like <template>
+        if let Some(head) = head {
+            for child in head.children.borrow().iter() {
+                if matches!(
+                    child.data,
+                    NodeData::Element { .. } | NodeData::Comment { .. }
+                ) {
+                    nodes.push(child.clone());
+                }
+            }
+        }
+
+        if let Some(body) = body {
+            nodes.extend(body.children.borrow().iter().cloned());
+        }
+
+        nodes
+    } else {
+        children.iter().cloned().collect()
+    }
+}
+
+/// Get the effective children of a node (handles template_contents).
+fn effective_children(node: &Handle) -> Vec<Handle> {
+    if let NodeData::Element {
+        template_contents, ..
+    } = &node.data
+        && let Some(tmpl) = template_contents.borrow().as_ref()
+    {
+        return tmpl.children.borrow().iter().cloned().collect();
+    }
+    node.children.borrow().iter().cloned().collect()
+}
+
+/// Check if an element has mixed content (text interleaved with element children).
+fn has_mixed_content(node: &Handle) -> bool {
+    let children = effective_children(node);
+    let has_elements = children
+        .iter()
+        .any(|c| matches!(c.data, NodeData::Element { .. }));
+    let has_significant_text = children.iter().any(|c| {
+        if let NodeData::Text { contents } = &c.data {
+            !contents.borrow().trim().is_empty()
+        } else {
+            false
+        }
+    });
+    has_elements && has_significant_text
+}
+
+/// Serialize a node's children back to raw HTML (for mixed content).
+fn serialize_inner_html(node: &Handle) -> String {
+    let mut html = String::new();
+    for child in &effective_children(node) {
+        serialize_node_to_html(child, &mut html);
+    }
+    html
+}
+
+fn serialize_node_to_html(node: &Handle, output: &mut String) {
+    match &node.data {
+        NodeData::Text { contents } => {
+            output.push_str(&contents.borrow());
+        }
+        NodeData::Element { name, attrs, .. } => {
+            let tag = name.local.as_ref();
+            output.push('<');
+            output.push_str(tag);
+            for attr in attrs.borrow().iter() {
+                output.push(' ');
+                output.push_str(attr.name.local.as_ref());
+                output.push_str("=\"");
+                output.push_str(&attr.value);
+                output.push('"');
+            }
+            if is_void_element(tag) {
+                output.push_str(" />");
+            } else {
+                output.push('>');
+                for child in &effective_children(node) {
+                    serialize_node_to_html(child, output);
+                }
+                output.push_str("</");
+                output.push_str(tag);
+                output.push('>');
+            }
+        }
+        NodeData::Comment { contents } => {
+            output.push_str("<!--");
+            output.push_str(contents);
+            output.push_str("-->");
+        }
+        _ => {}
+    }
+}
+
+fn emit_node(node: &Handle, depth: usize, output: &mut String) {
+    match &node.data {
+        NodeData::Doctype { name, .. } => {
+            output.push_str(&format!("doctype {name}\n"));
+        }
+        NodeData::Element { name, attrs, .. } => {
+            emit_element(node, &name.local, &attrs.borrow(), depth, output);
+        }
+        NodeData::Comment { contents } => {
+            let indent = " ".repeat(depth * INDENT_SIZE);
+            let text = contents.trim();
+            output.push_str(&format!("{indent}//! {text}\n"));
+        }
+        NodeData::Text { contents } => {
+            // Standalone text nodes (not inside an element) — should not happen
+            // in well-formed HTML, but handle gracefully
+            let text = contents.borrow().to_string();
+            if !text.trim().is_empty() {
+                let indent = " ".repeat(depth * INDENT_SIZE);
+                output.push_str(&format!("{indent}| {}\n", text.trim()));
+            }
+        }
+        _ => {}
+    }
+}
+
+fn emit_element(
+    node: &Handle,
+    tag: &str,
+    attrs: &[html5ever::interface::Attribute],
+    depth: usize,
+    output: &mut String,
+) {
+    let indent = " ".repeat(depth * INDENT_SIZE);
+
+    // Extract id and class from attributes
+    let mut id: Option<&str> = None;
+    let mut classes: Vec<&str> = Vec::new();
+    let mut other_attrs: Vec<(&str, &StrTendril)> = Vec::new();
+
+    for attr in attrs {
+        let key = attr.name.local.as_ref();
+        match key {
+            "id" => id = Some(&attr.value),
+            "class" => {
+                classes.extend(attr.value.split_whitespace());
+            }
+            _ => {
+                other_attrs.push((key, &attr.value));
+            }
+        }
+    }
+
+    // Build tag line
+    let mut line = String::new();
+
+    // Implicit div: omit "div" when there are selectors
+    let is_implicit_div = tag == "div" && (id.is_some() || !classes.is_empty());
+    if !is_implicit_div {
+        line.push_str(tag);
+    }
+
+    // Append #id
+    if let Some(id) = id {
+        line.push('#');
+        line.push_str(id);
+    }
+
+    // Append .classes
+    for class in &classes {
+        line.push('.');
+        line.push_str(class);
+    }
+
+    // Append (attributes)
+    if !other_attrs.is_empty() {
+        line.push('(');
+        for (i, (key, value)) in other_attrs.iter().enumerate() {
+            if i > 0 {
+                line.push_str(", ");
+            }
+            if value.is_empty() {
+                // Boolean attribute
+                line.push_str(key);
+            } else {
+                line.push_str(key);
+                line.push_str("=\"");
+                line.push_str(value);
+                line.push('"');
+            }
+        }
+        line.push(')');
+    }
+
+    // Handle children
+    let children = effective_children(node);
+    let significant_children: Vec<&Handle> = children
+        .iter()
+        .filter(|c| match &c.data {
+            NodeData::Text { contents } => !contents.borrow().trim().is_empty(),
+            NodeData::Element { .. } | NodeData::Comment { .. } => true,
+            _ => false,
+        })
+        .collect();
+
+    if is_void_element(tag) {
+        // Void elements: no children
+        output.push_str(&format!("{indent}{line}\n"));
+        return;
+    }
+
+    if significant_children.is_empty() {
+        // No content
+        output.push_str(&format!("{indent}{line}\n"));
+        return;
+    }
+
+    // Check for mixed content
+    if has_mixed_content(node) {
+        let inner = serialize_inner_html(node);
+        let trimmed = inner.trim();
+        if trimmed.contains('\n') {
+            // Multi-line mixed content → text block
+            output.push_str(&format!("{indent}{line}.\n"));
+            let text_indent = " ".repeat((depth + 1) * INDENT_SIZE);
+            for text_line in trimmed.lines() {
+                output.push_str(&format!("{text_indent}{text_line}\n"));
+            }
+        } else {
+            // Single-line mixed content → inline text
+            output.push_str(&format!("{indent}{line} {trimmed}\n"));
+        }
+        return;
+    }
+
+    // Check if only text content (no element children)
+    let text_only = significant_children
+        .iter()
+        .all(|c| matches!(c.data, NodeData::Text { .. }));
+
+    if text_only {
+        let text: String = significant_children
+            .iter()
+            .filter_map(|c| {
+                if let NodeData::Text { contents } = &c.data {
+                    Some(contents.borrow().trim().to_string())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        if text.contains('\n') {
+            // Multi-line text → text block
+            output.push_str(&format!("{indent}{line}.\n"));
+            let text_indent = " ".repeat((depth + 1) * INDENT_SIZE);
+            for text_line in text.lines() {
+                output.push_str(&format!("{text_indent}{text_line}\n"));
+            }
+        } else {
+            // Single-line text → inline
+            output.push_str(&format!("{indent}{line} {text}\n"));
+        }
+        return;
+    }
+
+    // Element children only — recurse
+    output.push_str(&format!("{indent}{line}\n"));
+    for child in &significant_children {
+        emit_node(child, depth + 1, output);
+    }
+}

--- a/src/converter/emitter.rs
+++ b/src/converter/emitter.rs
@@ -294,10 +294,14 @@ fn emit_element(
 
     // Handle children
     let children = effective_children(node);
+    let whitespace_sensitive = matches!(tag, "pre" | "textarea" | "script" | "style");
+
     let significant_children: Vec<&Handle> = children
         .iter()
         .filter(|c| match &c.data {
-            NodeData::Text { contents } => !contents.borrow().trim().is_empty(),
+            NodeData::Text { contents } => {
+                whitespace_sensitive || !contents.borrow().trim().is_empty()
+            }
             NodeData::Element { .. } | NodeData::Comment { .. } => true,
             _ => false,
         })
@@ -312,6 +316,27 @@ fn emit_element(
     if significant_children.is_empty() {
         // No content
         output.push_str(&format!("{indent}{line}\n"));
+        return;
+    }
+
+    // Whitespace-sensitive tags: preserve content exactly as text block
+    if whitespace_sensitive {
+        let raw: String = significant_children
+            .iter()
+            .filter_map(|c| {
+                if let NodeData::Text { contents } = &c.data {
+                    Some(contents.borrow().to_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        output.push_str(&format!("{indent}{line}.\n"));
+        let text_indent = " ".repeat((depth + 1) * INDENT_SIZE);
+        for text_line in raw.lines() {
+            output.push_str(&format!("{text_indent}{text_line}\n"));
+        }
         return;
     }
 

--- a/src/converter/emitter.rs
+++ b/src/converter/emitter.rs
@@ -95,12 +95,12 @@ fn effective_children(node: &Handle) -> Vec<Handle> {
     node.children.borrow().iter().cloned().collect()
 }
 
-/// Check if an element has mixed content (text interleaved with element children).
+/// Check if an element has mixed content (text interleaved with element or comment children).
 fn has_mixed_content(node: &Handle) -> bool {
     let children = effective_children(node);
-    let has_elements = children
+    let has_non_text = children
         .iter()
-        .any(|c| matches!(c.data, NodeData::Element { .. }));
+        .any(|c| matches!(c.data, NodeData::Element { .. } | NodeData::Comment { .. }));
     let has_significant_text = children.iter().any(|c| {
         if let NodeData::Text { contents } = &c.data {
             !contents.borrow().trim().is_empty()
@@ -108,7 +108,7 @@ fn has_mixed_content(node: &Handle) -> bool {
             false
         }
     });
-    has_elements && has_significant_text
+    has_non_text && has_significant_text
 }
 
 /// Serialize a node's children back to raw HTML (for mixed content).
@@ -211,14 +211,9 @@ fn emit_node(node: &Handle, depth: usize, output: &mut String) {
             let text = contents.trim();
             output.push_str(&format!("{indent}//! {text}\n"));
         }
-        NodeData::Text { contents } => {
-            // Standalone text nodes (not inside an element) — should not happen
-            // in well-formed HTML, but handle gracefully
-            let text = contents.borrow().to_string();
-            if !text.trim().is_empty() {
-                let indent = " ".repeat(depth * INDENT_SIZE);
-                output.push_str(&format!("{indent}| {}\n", text.trim()));
-            }
+        NodeData::Text { .. } => {
+            // Standalone text nodes outside elements are ignored.
+            // Significant text inside elements is handled by emit_element.
         }
         _ => {}
     }

--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -11,7 +11,7 @@ pub fn convert(html: &str) -> Result<String, String> {
         .read_from(&mut html.as_bytes())
         .map_err(|e| format!("HTML parse error: {e}"))?;
 
-    Ok(emitter::emit(&dom))
+    Ok(emitter::emit(&dom, html))
 }
 
 #[cfg(test)]

--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -1,0 +1,18 @@
+mod emitter;
+
+use html5ever::parse_document;
+use html5ever::tendril::TendrilSink;
+use markup5ever_rcdom::RcDom;
+
+/// Convert an HTML string to HSML source.
+pub fn convert(html: &str) -> Result<String, String> {
+    let dom = parse_document(RcDom::default(), Default::default())
+        .from_utf8()
+        .read_from(&mut html.as_bytes())
+        .map_err(|e| format!("HTML parse error: {e}"))?;
+
+    Ok(emitter::emit(&dom))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/converter/tests/convert.rs
+++ b/src/converter/tests/convert.rs
@@ -221,6 +221,46 @@ fn it_should_keep_ampersands_in_angular_directive_values() {
     );
 }
 
+// --- Whitespace-sensitive tags ---
+
+#[test]
+fn it_should_preserve_whitespace_in_pre_tag() {
+    // Pre tag content preserves original whitespace via text block syntax.
+    // Text block indent is (depth+1)*2 = 2 spaces, original content on top.
+    assert_eq!(
+        conv("<pre>  line 1\n  line 2\n    indented</pre>"),
+        "pre.\n    line 1\n    line 2\n      indented\n"
+    );
+}
+
+#[test]
+fn it_should_preserve_whitespace_in_pre_tag_with_class() {
+    assert_eq!(
+        conv(
+            "<pre class=\"hljs language-rust\">fn main() {\n    println!(\"Hello, world!\");\n}</pre>"
+        ),
+        "pre.hljs.language-rust.\n  fn main() {\n      println!(\"Hello, world!\");\n  }\n"
+    );
+}
+
+#[test]
+fn it_should_preserve_whitespace_in_textarea() {
+    assert_eq!(
+        conv("<textarea>  some\n  text</textarea>"),
+        "textarea.\n    some\n    text\n"
+    );
+}
+
+#[test]
+#[ignore] // TODO: round-trip for pre tags loses leading whitespace — needs text block compiler fix
+fn it_should_roundtrip_pre_tag_content() {
+    let html = "<pre>  line 1\n  line 2</pre>";
+    let hsml = conv(html);
+
+    let compiled = crate::compile_content_core(&hsml).unwrap();
+    assert_eq!(compiled, html, "round-trip should preserve pre content");
+}
+
 // --- TailwindCSS ---
 
 #[test]

--- a/src/converter/tests/convert.rs
+++ b/src/converter/tests/convert.rs
@@ -179,6 +179,48 @@ fn it_should_escape_quotes_in_mixed_content_attributes() {
     );
 }
 
+// --- HTML entities in HSML attribute output ---
+
+#[test]
+fn it_should_escape_quotes_in_hsml_attribute_values() {
+    // An attribute value containing a double quote would break key="value" syntax
+    assert_eq!(
+        conv(r#"<div title="say &quot;hello&quot;"></div>"#),
+        r#"div(title="say &quot;hello&quot;")
+"#
+    );
+}
+
+#[test]
+fn it_should_reencode_ampersands_in_regular_hsml_attributes() {
+    // html5ever decodes &amp; to & — regular HTML attributes must re-encode
+    // so the compiled HTML output has valid &amp;
+    assert_eq!(
+        conv(r#"<a href="/search?a=1&amp;b=2">link</a>"#),
+        r#"a(href="/search?a=1&amp;b=2") link
+"#
+    );
+}
+
+#[test]
+fn it_should_keep_ampersands_in_vue_directive_values() {
+    // Vue directive values contain JS expressions where && is valid
+    assert_eq!(
+        conv(r#"<div :class="a && b"></div>"#),
+        r#"div(:class="a && b")
+"#
+    );
+}
+
+#[test]
+fn it_should_keep_ampersands_in_angular_directive_values() {
+    assert_eq!(
+        conv(r#"<div [class]="a && b"></div>"#),
+        r#"div([class]="a && b")
+"#
+    );
+}
+
 // --- TailwindCSS ---
 
 #[test]

--- a/src/converter/tests/convert.rs
+++ b/src/converter/tests/convert.rs
@@ -152,6 +152,36 @@ fn it_should_keep_complex_mixed_content_as_raw_html() {
     );
 }
 
+#[test]
+fn it_should_handle_multiline_mixed_content_as_text_block() {
+    assert_eq!(
+        conv("<p>Hello\n<strong>World</strong>\nmore</p>"),
+        "p.\n  Hello\n  <strong>World</strong>\n  more\n"
+    );
+}
+
+#[test]
+fn it_should_handle_mixed_content_with_void_element() {
+    assert_eq!(conv("<p>Hello<br>World</p>"), "p Hello<br />World\n");
+}
+
+#[test]
+fn it_should_handle_mixed_content_with_comment() {
+    // Comments interleaved with text are treated as mixed content
+    assert_eq!(
+        conv("<p>Hello<!-- separator -->World</p>"),
+        "p Hello<!-- separator -->World\n"
+    );
+}
+
+#[test]
+fn it_should_handle_multiline_text_as_text_block() {
+    assert_eq!(
+        conv("<p>Line one\nLine two\nLine three</p>"),
+        "p.\n  Line one\n  Line two\n  Line three\n"
+    );
+}
+
 // --- HTML entities in mixed content ---
 
 #[test]

--- a/src/converter/tests/convert.rs
+++ b/src/converter/tests/convert.rs
@@ -385,6 +385,15 @@ fn it_should_not_escape_style_content() {
     );
 }
 
+#[test]
+fn it_should_not_escape_script_in_mixed_content() {
+    assert_eq!(
+        conv(r#"<div>text<script>if (a < b) {}</script>more</div>"#),
+        r#"div text<script>if (a < b) {}</script>more
+"#
+    );
+}
+
 // --- TailwindCSS ---
 
 #[test]

--- a/src/converter/tests/convert.rs
+++ b/src/converter/tests/convert.rs
@@ -1,0 +1,319 @@
+use crate::converter::convert;
+
+fn conv(html: &str) -> String {
+    convert(html).unwrap()
+}
+
+// --- Basic tags ---
+
+#[test]
+fn it_should_convert_simple_tag() {
+    assert_eq!(conv("<p>Hello</p>"), "p Hello\n");
+}
+
+#[test]
+fn it_should_convert_empty_tag() {
+    assert_eq!(conv("<div></div>"), "div\n");
+}
+
+#[test]
+fn it_should_convert_nested_tags() {
+    assert_eq!(conv("<div><p>Hello</p></div>"), "div\n  p Hello\n");
+}
+
+#[test]
+fn it_should_convert_deeply_nested_tags() {
+    assert_eq!(
+        conv("<div><section><p>Hello</p></section></div>"),
+        "div\n  section\n    p Hello\n"
+    );
+}
+
+// --- Implicit div ---
+
+#[test]
+fn it_should_convert_div_with_class_to_implicit_div() {
+    assert_eq!(conv("<div class=\"card\">Hello</div>"), ".card Hello\n");
+}
+
+#[test]
+fn it_should_convert_div_with_id_to_implicit_div() {
+    assert_eq!(conv("<div id=\"app\"></div>"), "#app\n");
+}
+
+#[test]
+fn it_should_convert_div_with_id_and_classes() {
+    assert_eq!(
+        conv("<div id=\"app\" class=\"container main\"></div>"),
+        "#app.container.main\n"
+    );
+}
+
+#[test]
+fn it_should_not_use_implicit_div_for_other_tags() {
+    assert_eq!(
+        conv("<span class=\"highlight\">text</span>"),
+        "span.highlight text\n"
+    );
+}
+
+// --- Attributes ---
+
+#[test]
+fn it_should_convert_attributes() {
+    assert_eq!(
+        conv("<a href=\"https://github.com\" target=\"_blank\">GitHub</a>"),
+        "a(href=\"https://github.com\", target=\"_blank\") GitHub\n"
+    );
+}
+
+#[test]
+fn it_should_convert_boolean_attributes() {
+    assert_eq!(
+        conv("<button disabled>Click</button>"),
+        "button(disabled) Click\n"
+    );
+}
+
+#[test]
+fn it_should_extract_id_and_class_from_attributes() {
+    assert_eq!(
+        conv("<img id=\"photo\" class=\"rounded\" src=\"photo.jpg\">"),
+        "img#photo.rounded(src=\"photo.jpg\")\n"
+    );
+}
+
+// --- Vue/Angular syntax ---
+
+#[test]
+fn it_should_preserve_vue_attributes() {
+    assert_eq!(
+        conv("<button @click=\"handleClick\" :class=\"dynamicClass\" v-if=\"show\">Click</button>"),
+        "button(@click=\"handleClick\", :class=\"dynamicClass\", v-if=\"show\") Click\n"
+    );
+}
+
+#[test]
+fn it_should_convert_template_and_slot() {
+    assert_eq!(
+        conv("<template #default><p>Content</p></template>"),
+        "template(#default)\n  p Content\n"
+    );
+}
+
+// --- Void elements ---
+
+#[test]
+fn it_should_convert_void_elements() {
+    assert_eq!(conv("<br>"), "br\n");
+    assert_eq!(conv("<hr>"), "hr\n");
+    assert_eq!(
+        conv("<img src=\"photo.jpg\" alt=\"Photo\">"),
+        "img(src=\"photo.jpg\", alt=\"Photo\")\n"
+    );
+    assert_eq!(
+        conv("<input type=\"text\" placeholder=\"Name\">"),
+        "input(type=\"text\", placeholder=\"Name\")\n"
+    );
+}
+
+// --- Comments ---
+
+#[test]
+fn it_should_convert_comments() {
+    assert_eq!(conv("<!-- Hello -->"), "//! Hello\n");
+}
+
+// --- DOCTYPE ---
+
+#[test]
+fn it_should_convert_doctype() {
+    assert_eq!(
+        conv("<!DOCTYPE html><html><head></head><body><p>Hello</p></body></html>"),
+        "doctype html\nhtml\n  head\n  body\n    p Hello\n"
+    );
+}
+
+// --- Mixed content ---
+
+#[test]
+fn it_should_keep_mixed_content_as_raw_html() {
+    assert_eq!(
+        conv("<p>Hello <strong>World</strong> more</p>"),
+        "p Hello <strong>World</strong> more\n"
+    );
+}
+
+#[test]
+fn it_should_keep_complex_mixed_content_as_raw_html() {
+    assert_eq!(
+        conv("<p>Visit <a href=\"https://example.com\">example</a> now</p>"),
+        "p Visit <a href=\"https://example.com\">example</a> now\n"
+    );
+}
+
+// --- TailwindCSS ---
+
+#[test]
+fn it_should_handle_tailwind_classes() {
+    assert_eq!(
+        conv("<div class=\"bg-[#1da1f2] lg:flex md:p-0\">Hello</div>"),
+        ".bg-[#1da1f2].lg:flex.md:p-0 Hello\n"
+    );
+}
+
+// --- Multiple root elements ---
+
+#[test]
+fn it_should_handle_multiple_root_elements() {
+    assert_eq!(conv("<p>One</p><p>Two</p>"), "p One\np Two\n");
+}
+
+// --- Whitespace ---
+
+#[test]
+fn it_should_ignore_insignificant_whitespace() {
+    assert_eq!(conv("<div>\n  <p>Hello</p>\n</div>"), "div\n  p Hello\n");
+}
+
+// --- Real-world examples ---
+
+#[test]
+fn it_should_convert_vue_card_component_html() {
+    let html = r#"<h1 class="text-red">Vite CJS Faker Demo</h1>
+<div class="card">
+  <div class="card__image">
+    <img :src="natureImageUrl" :alt="'Background image for ' + fullName" />
+  </div>
+  <div class="card__profile">
+    <img :src="avatarUrl" :alt="'Avatar image of ' + fullName" />
+  </div>
+  <div class="card__body">{{ fullName }}</div>
+</div>"#;
+
+    assert_eq!(
+        conv(html),
+        r#"h1.text-red Vite CJS Faker Demo
+.card
+  .card__image
+    img(:src="natureImageUrl", :alt="'Background image for ' + fullName")
+  .card__profile
+    img(:src="avatarUrl", :alt="'Avatar image of ' + fullName")
+  .card__body {{ fullName }}
+"#
+    );
+}
+
+#[test]
+fn it_should_convert_tailwind_figure_html() {
+    let html = r#"<!-- test comment on root layer -->
+<figure class="md:flex bg-slate-100 rounded-xl p-8 md:p-0 dark:bg-slate-800/10">
+  <!-- test comment --><img class="w-24 h-24 md:w-48 md:h-auto md:rounded-none rounded-full mx-auto" src="/fancy-avatar.jpg" alt="" width="384" height="512" />
+  <div class="pt-6 md:p-8 text-center md:text-left space-y-4">
+    <blockquote v-if="showBlockquote">
+      <p class="text-lg font-medium">"Tailwind CSS is the only framework that I've seen scale on large teams. It's easy to customize, adapts to any design, and the build size is tiny."</p>
+    </blockquote>
+    <figcaption class="font-medium">
+      <div class="text-sky-500 dark:text-sky-400">Sarah Dayan</div>
+      <div class="text-[#af05c9] dark:text-slate-500">Staff Engineer, Algolia</div>
+    </figcaption>
+  </div>
+</figure>"#;
+
+    assert_eq!(
+        conv(html),
+        r#"//! test comment on root layer
+figure.md:flex.bg-slate-100.rounded-xl.p-8.md:p-0.dark:bg-slate-800/10
+  //! test comment
+  img.w-24.h-24.md:w-48.md:h-auto.md:rounded-none.rounded-full.mx-auto(src="/fancy-avatar.jpg", alt, width="384", height="512")
+  .pt-6.md:p-8.text-center.md:text-left.space-y-4
+    blockquote(v-if="showBlockquote")
+      p.text-lg.font-medium "Tailwind CSS is the only framework that I've seen scale on large teams. It's easy to customize, adapts to any design, and the build size is tiny."
+    figcaption.font-medium
+      .text-sky-500.dark:text-sky-400 Sarah Dayan
+      .text-[#af05c9].dark:text-slate-500 Staff Engineer, Algolia
+"#
+    );
+}
+
+#[test]
+fn it_should_convert_complex_vue_html() {
+    // TODO @Shinigami92 2026-04-06: PascalCase tags are currently not supported by html5ever
+    let html = r#"<div ref="container" :class="containerClass">
+  <div
+    class="sticky top-0 z-20"
+    pt="[env(safe-area-inset-top,0)]"
+    bg="[rgba(var(--rgb-bg-base),0.7)]"
+    :class="{
+      'backdrop-blur': !getPreferences(userSettings, 'optimizeForLowPerformanceDevice'),
+    }"
+  >
+    <div
+      class="min-h-53px px-2 py-1"
+      flex="~ justify-between"
+      :class="{ 'xl:hidden': $route.name !== 'tag' }"
+      border="b base"
+    >
+      <div class="w-full" flex="~ items-center">
+        <button
+          class="btn-text flex items-center p-3 xl:hidden"
+          v-if="backOnSmallScreen || showBackButton"
+          :aria-label="$t('nav.back')"
+          @click="$router.go(-1)"
+        >
+          <div class="text-lg rtl-flip" i-ri:arrow-left-line></div>
+        </button>
+        <div class="flex w-full"><slot name="title"></slot></div>
+        <div class="sm:hidden h-7 w-1px"></div>
+      </div>
+      <div class="px-3" flex="~ items-center shrink-0 gap-x-2">
+        <slot name="actions"></slot>
+        <pwa-badge class="xl:hidden"></pwa-badge>
+        <nav-user v-if="isHydrated"></nav-user>
+        <nav-user-skeleton v-else></nav-user-skeleton>
+      </div>
+    </div>
+    <slot name="header"><div hidden></div></slot>
+  </div>
+  <pwa-install-prompt class="xl:hidden"></pwa-install-prompt>
+  <div
+    class="m-auto"
+    :class="isHydrated && wideLayout ? 'xl:w-full sm:max-w-600px' : 'sm:max-w-600px md:shrink-0'"
+  >
+    <div
+      class="h-6"
+      hidden
+      :class="{ 'xl:block': $route.name !== 'tag' && !$slots.header }"
+    ></div>
+    <slot></slot>
+  </div>
+</div>
+"#;
+
+    assert_eq!(
+        conv(html),
+        r#"div(ref="container", :class="containerClass")
+  .sticky.top-0.z-20(pt="[env(safe-area-inset-top,0)]", bg="[rgba(var(--rgb-bg-base),0.7)]", :class="{
+      'backdrop-blur': !getPreferences(userSettings, 'optimizeForLowPerformanceDevice'),
+    }")
+    .min-h-53px.px-2.py-1(flex="~ justify-between", :class="{ 'xl:hidden': $route.name !== 'tag' }", border="b base")
+      .w-full(flex="~ items-center")
+        button.btn-text.flex.items-center.p-3.xl:hidden(v-if="backOnSmallScreen || showBackButton", :aria-label="$t('nav.back')", @click="$router.go(-1)")
+          .text-lg.rtl-flip(i-ri:arrow-left-line)
+        .flex.w-full
+          slot(name="title")
+        .sm:hidden.h-7.w-1px
+      .px-3(flex="~ items-center shrink-0 gap-x-2")
+        slot(name="actions")
+        pwa-badge.xl:hidden
+        nav-user(v-if="isHydrated")
+        nav-user-skeleton(v-else)
+    slot(name="header")
+      div(hidden)
+  pwa-install-prompt.xl:hidden
+  .m-auto(:class="isHydrated && wideLayout ? 'xl:w-full sm:max-w-600px' : 'sm:max-w-600px md:shrink-0'")
+    .h-6(hidden, :class="{ 'xl:block': $route.name !== 'tag' && !$slots.header }")
+    slot
+"#
+    );
+}

--- a/src/converter/tests/convert.rs
+++ b/src/converter/tests/convert.rs
@@ -152,6 +152,33 @@ fn it_should_keep_complex_mixed_content_as_raw_html() {
     );
 }
 
+// --- HTML entities in mixed content ---
+
+#[test]
+fn it_should_escape_entities_in_mixed_content_text() {
+    // html5ever decodes &amp; to & in the DOM — serialize_inner_html must re-encode
+    assert_eq!(
+        conv("<p>A &amp; B <strong>bold</strong></p>"),
+        "p A &amp; B <strong>bold</strong>\n"
+    );
+}
+
+#[test]
+fn it_should_escape_lt_gt_in_mixed_content_text() {
+    assert_eq!(
+        conv("<p>Use &lt;div&gt; for <em>containers</em></p>"),
+        "p Use &lt;div&gt; for <em>containers</em>\n"
+    );
+}
+
+#[test]
+fn it_should_escape_quotes_in_mixed_content_attributes() {
+    assert_eq!(
+        conv("<p>Click <a href=\"/search?q=a&amp;b\">here</a> now</p>"),
+        "p Click <a href=\"/search?q=a&amp;b\">here</a> now\n"
+    );
+}
+
 // --- TailwindCSS ---
 
 #[test]

--- a/src/converter/tests/convert.rs
+++ b/src/converter/tests/convert.rs
@@ -349,6 +349,42 @@ fn it_should_roundtrip_pre_tag_content() {
     assert_eq!(compiled, html, "round-trip should preserve pre content");
 }
 
+// --- Pre with nested markup ---
+
+#[test]
+fn it_should_preserve_nested_markup_in_pre() {
+    assert_eq!(
+        conv("<pre><code>hello</code></pre>"),
+        "pre.\n  <code>hello</code>\n"
+    );
+}
+
+#[test]
+fn it_should_preserve_nested_markup_with_whitespace_in_pre() {
+    assert_eq!(
+        conv("<pre><code>  fn main() {\n    println!(\"hi\");\n  }</code></pre>"),
+        "pre.\n  <code>  fn main() {\n      println!(\"hi\");\n    }</code>\n"
+    );
+}
+
+// --- Script/style raw text ---
+
+#[test]
+fn it_should_not_escape_script_content_in_mixed_serialization() {
+    assert_eq!(
+        conv("<script>if (a < b && c > d) {}</script>"),
+        "script.\n  if (a < b && c > d) {}\n"
+    );
+}
+
+#[test]
+fn it_should_not_escape_style_content() {
+    assert_eq!(
+        conv("<style>.foo > .bar { color: red; }</style>"),
+        "style.\n  .foo > .bar { color: red; }\n"
+    );
+}
+
 // --- TailwindCSS ---
 
 #[test]
@@ -371,6 +407,17 @@ fn it_should_handle_multiple_root_elements() {
 #[test]
 fn it_should_ignore_insignificant_whitespace() {
     assert_eq!(conv("<div>\n  <p>Hello</p>\n</div>"), "div\n  p Hello\n");
+}
+
+// --- Explicit html/body without DOCTYPE ---
+
+#[test]
+fn it_should_preserve_explicit_html_body_without_doctype() {
+    // <head> is synthesized by html5ever but not in the source — should be skipped
+    assert_eq!(
+        conv("<html><body><p>Hello</p></body></html>"),
+        "html\n  body\n    p Hello\n"
+    );
 }
 
 // --- Real-world examples ---

--- a/src/converter/tests/convert.rs
+++ b/src/converter/tests/convert.rs
@@ -83,6 +83,56 @@ fn it_should_extract_id_and_class_from_attributes() {
     );
 }
 
+// --- IDs and classes with special characters ---
+
+#[test]
+fn it_should_escape_id_with_hash() {
+    // id="foo#bar" can't use #foo#bar syntax — ambiguous
+    assert_eq!(
+        conv(r#"<div id="foo#bar"></div>"#),
+        r#"div(id="foo#bar")
+"#
+    );
+}
+
+#[test]
+fn it_should_escape_class_with_dot() {
+    // class="btn.primary" can't use .btn.primary syntax — ambiguous
+    assert_eq!(
+        conv(r#"<div class="btn.primary"></div>"#),
+        r#"div(class="btn.primary")
+"#
+    );
+}
+
+#[test]
+fn it_should_fallback_entire_class_when_one_contains_dot() {
+    // Safe classes use shorthand, unsafe ones fall back to attribute syntax
+    assert_eq!(
+        conv(r#"<div class="container btn.primary active"></div>"#),
+        r#".container.active(class="btn.primary")
+"#
+    );
+}
+
+#[test]
+fn it_should_use_shorthand_for_tailwind_arbitrary_color() {
+    // bg-[#1da1f2] has # inside brackets — safe for shorthand
+    assert_eq!(
+        conv(r#"<div class="bg-[#1da1f2] text-white"></div>"#),
+        ".bg-[#1da1f2].text-white\n"
+    );
+}
+
+#[test]
+fn it_should_handle_normal_id_and_class() {
+    // Normal id/class without special chars — use shorthand
+    assert_eq!(
+        conv(r#"<div id="app" class="container main"></div>"#),
+        "#app.container.main\n"
+    );
+}
+
 // --- Vue/Angular syntax ---
 
 #[test]

--- a/src/converter/tests/convert.rs
+++ b/src/converter/tests/convert.rs
@@ -124,6 +124,14 @@ fn it_should_convert_comments() {
     assert_eq!(conv("<!-- Hello -->"), "//! Hello\n");
 }
 
+#[test]
+fn it_should_convert_multiline_comment() {
+    assert_eq!(
+        conv("<!-- line one\nline two -->"),
+        "//! line one\n//! line two\n"
+    );
+}
+
 // --- DOCTYPE ---
 
 #[test]

--- a/src/converter/tests/mod.rs
+++ b/src/converter/tests/mod.rs
@@ -1,0 +1,1 @@
+mod convert;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod common;
 pub mod compiler;
+pub mod converter;
 pub mod diagnostic;
 pub mod formatter;
 pub mod parser;
@@ -109,6 +110,11 @@ pub fn compile_content_diagnostics(
     Ok(CompileOutput { html, diagnostics })
 }
 
+/// Core convert logic shared by WASM and native callers.
+pub fn convert_html_core(html: &str) -> Result<String, String> {
+    converter::convert(html)
+}
+
 /// Core format logic shared by WASM and native callers.
 pub fn format_content_core(
     source: &str,
@@ -163,6 +169,14 @@ pub fn format_content(source: &str, options: JsValue) -> Result<String, JsError>
     };
 
     format_content_core(source, &options).map_err(|e| JsError::new(&e))
+}
+
+/// Convert HTML to HSML, exposed as a WASM binding.
+///
+/// Returns the converted HSML string, or a `JsError` on parse failure.
+#[wasm_bindgen(js_name = "convertHtml")]
+pub fn convert_html(html: &str) -> Result<String, JsError> {
+    convert_html_core(html).map_err(|e| JsError::new(&e))
 }
 
 /// Compile HSML source to HTML, exposed as a WASM binding.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add HTML → HSML conversion with robust HTML5 parsing, preserving doctype, comments, attributes, templates, directives, and whitespace-sensitive content; exposed to native and WASM callers with clear error reporting.

* **Tests**
  * Add extensive end-to-end tests for nesting, multiple roots, void elements, mixed content, attribute serialization, directives, and real-world templates/Tailwind.

* **Chores**
  * Add HTML parsing dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->