### PR TITLE
docs: add playground link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A pug-inspired HTML preprocessor, written in Rust. Less typing, more shipping.
 
 > Still young and growing! Some features are cooking. Check out the [roadmap](#roadmap) below.
 
+**[Try it live in the Playground](https://hsml-lab.github.io/playground/)**
+
 ## What is it?
 
 HSML compiles a short, indentation-based syntax into HTML — think [Pug](https://pugjs.org), but leaner:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a prominent "Try it live in the Playground" link to the project documentation for easier access to interactive features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->