### PR TITLE
feat: add pretty-printed HTML compilation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Patch TypeScript types
         shell: bash
         run: |
-          sed -i 's/compileContentWithDiagnostics(source: string): any/compileContentWithDiagnostics(source: string): CompileResult/' pkg/hsml.d.ts
+          sed -i 's/compileContentWithDiagnostics(source: string, options: any)/compileContentWithDiagnostics(source: string, options?: CompileOptions): CompileResult/' pkg/hsml.d.ts
           sed -i 's/formatContent(source: string, options: any)/formatContent(source: string, options?: FormatContentOptions)/' pkg/hsml.d.ts
           {
             echo ''
@@ -82,6 +82,14 @@ jobs:
             echo '  location?: Location;'
             echo '  /** File path, if available. */'
             echo '  filePath?: string;'
+            echo '}'
+            echo ''
+            echo '/** Options for compiling HSML source. */'
+            echo 'export interface CompileOptions {'
+            echo '  /** Emit pretty-printed HTML with indentation (default: false). */'
+            echo '  pretty?: boolean;'
+            echo '  /** Number of spaces per indentation level (default: 2). */'
+            echo '  indentSize?: number;'
             echo '}'
             echo ''
             echo '/** Result of compiling HSML source with diagnostic support. */'

--- a/src/cli/exec_compile.rs
+++ b/src/cli/exec_compile.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use clap::ArgMatches;
-use hsml::compile_content_diagnostics;
+use hsml::compile_content_diagnostics_with_options;
 
 use super::common::{resolve_ignore_patterns, resolve_path, validate_hsml_extension};
 use super::diagnostics::{
@@ -19,6 +19,7 @@ pub fn exec_compile(matches: &ArgMatches) -> Result<(), String> {
         .get_one::<String>("report_format")
         .map(|s| s.as_str());
     let debug = matches.get_flag("debug");
+    let pretty = matches.get_flag("pretty");
     let (no_color, dim) = resolve_colors(matches);
     let ignore_patterns = resolve_ignore_patterns(matches);
     let path = resolve_path(matches)?;
@@ -45,9 +46,15 @@ pub fn exec_compile(matches: &ArgMatches) -> Result<(), String> {
                 io_errors.extend(result.errors);
                 file_count = result.files.len();
                 for file in &result.files {
-                    if let Err(e) =
-                        compile_file(file, None, debug, dim, &mut diagnostics, &mut io_errors)
-                    {
+                    if let Err(e) = compile_file(
+                        file,
+                        None,
+                        pretty,
+                        debug,
+                        dim,
+                        &mut diagnostics,
+                        &mut io_errors,
+                    ) {
                         io_errors.push(e);
                     }
                 }
@@ -56,7 +63,15 @@ pub fn exec_compile(matches: &ArgMatches) -> Result<(), String> {
         }
     } else if path.is_file() {
         file_count = 1;
-        if let Err(e) = compile_file(path, out, debug, dim, &mut diagnostics, &mut io_errors) {
+        if let Err(e) = compile_file(
+            path,
+            out,
+            pretty,
+            debug,
+            dim,
+            &mut diagnostics,
+            &mut io_errors,
+        ) {
             io_errors.push(e);
         }
     } else {
@@ -89,6 +104,7 @@ pub fn exec_compile(matches: &ArgMatches) -> Result<(), String> {
 fn compile_file(
     file: &Path,
     out_file: Option<&PathBuf>,
+    pretty: bool,
     debug: bool,
     dim: (&str, &str),
     diagnostics: &mut Vec<FileDiagnostics>,
@@ -112,7 +128,12 @@ fn compile_file(
 
     let start = Instant::now();
 
-    match compile_content_diagnostics(&content) {
+    let compile_options = hsml::compiler::HsmlCompileOptions {
+        pretty,
+        ..Default::default()
+    };
+
+    match compile_content_diagnostics_with_options(&content, &compile_options) {
         Ok(output) => {
             // Write HTML immediately — don't buffer
             if let Err(e) = fs::write(out_file, &output.html) {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -36,7 +36,8 @@ pub fn cli() -> Command {
                 .arg(
                     arg!(ignore_pattern: --"ignore-pattern" <PATTERN> "Glob pattern for files/directories to ignore")
                         .action(clap::ArgAction::Append),
-                ),
+                )
+                .arg(arg!(pretty: --pretty "Emit pretty-printed HTML with indentation")),
         )
         .subcommand(
             Command::new("parse")

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -5,12 +5,35 @@ use crate::parser::{
 };
 
 /// Options for configuring the HSML-to-HTML compiler.
-#[derive(Default)]
-pub struct HsmlCompileOptions {}
+pub struct HsmlCompileOptions {
+    /// Emit pretty-printed HTML with indentation and newlines.
+    pub pretty: bool,
+    /// Number of spaces per indentation level (only used when `pretty` is true).
+    pub indent_size: usize,
+}
 
-fn compile_tag_node(tag_node: &TagNode, _options: &HsmlCompileOptions) -> Result<String, String> {
+impl Default for HsmlCompileOptions {
+    fn default() -> Self {
+        Self {
+            pretty: false,
+            indent_size: 2,
+        }
+    }
+}
+
+fn compile_tag_node(
+    tag_node: &TagNode,
+    options: &HsmlCompileOptions,
+    depth: usize,
+) -> Result<String, String> {
     let mut html_content = String::new();
+    let indent = if options.pretty {
+        " ".repeat(depth * options.indent_size)
+    } else {
+        String::new()
+    };
 
+    html_content.push_str(&indent);
     html_content.push('<');
     html_content.push_str(&tag_node.tag);
 
@@ -63,6 +86,9 @@ fn compile_tag_node(tag_node: &TagNode, _options: &HsmlCompileOptions) -> Result
 
     if is_void_element(&tag_node.tag) {
         html_content.push_str(" />");
+        if options.pretty {
+            html_content.push('\n');
+        }
         return Ok(html_content);
     }
 
@@ -73,14 +99,21 @@ fn compile_tag_node(tag_node: &TagNode, _options: &HsmlCompileOptions) -> Result
     }
 
     if let Some(child_nodes) = &tag_node.children {
+        if options.pretty {
+            html_content.push('\n');
+        }
         for child_node in child_nodes {
             match child_node {
                 HsmlNode::Tag(tag_node) => {
-                    html_content.push_str(&compile_tag_node(tag_node, _options)?)
+                    html_content.push_str(&compile_tag_node(tag_node, options, depth + 1)?)
                 }
                 HsmlNode::Comment(comment_node) => {
                     if !comment_node.is_dev {
-                        html_content.push_str(&compile_comment_node(comment_node, _options))
+                        html_content.push_str(&compile_comment_node(
+                            comment_node,
+                            options,
+                            depth + 1,
+                        ))
                     }
                 }
                 other => {
@@ -91,21 +124,39 @@ fn compile_tag_node(tag_node: &TagNode, _options: &HsmlCompileOptions) -> Result
                 }
             }
         }
+        if options.pretty {
+            html_content.push_str(&indent);
+        }
     }
 
     html_content.push_str("</");
     html_content.push_str(&tag_node.tag);
     html_content.push('>');
+    if options.pretty {
+        html_content.push('\n');
+    }
 
     Ok(html_content)
 }
 
-fn compile_comment_node(comment_node: &CommentNode, _options: &HsmlCompileOptions) -> String {
+fn compile_comment_node(
+    comment_node: &CommentNode,
+    options: &HsmlCompileOptions,
+    depth: usize,
+) -> String {
     let mut html_content = String::new();
+
+    if options.pretty {
+        html_content.push_str(&" ".repeat(depth * options.indent_size));
+    }
 
     html_content.push_str("<!--");
     html_content.push_str(&comment_node.text);
     html_content.push_str(" -->");
+
+    if options.pretty {
+        html_content.push('\n');
+    }
 
     html_content
 }
@@ -114,12 +165,22 @@ fn compile_doctype_node(doctype_node: &DoctypeNode) -> String {
     format!("<!DOCTYPE {}>", doctype_node.doctype)
 }
 
-fn compile_node(node: &HsmlNode, options: &HsmlCompileOptions) -> Result<String, String> {
+fn compile_node(
+    node: &HsmlNode,
+    options: &HsmlCompileOptions,
+    depth: usize,
+) -> Result<String, String> {
     match node {
-        HsmlNode::Doctype(doctype_node) => Ok(compile_doctype_node(doctype_node)),
-        HsmlNode::Tag(tag_node) => compile_tag_node(tag_node, options),
+        HsmlNode::Doctype(doctype_node) => {
+            let mut s = compile_doctype_node(doctype_node);
+            if options.pretty {
+                s.push('\n');
+            }
+            Ok(s)
+        }
+        HsmlNode::Tag(tag_node) => compile_tag_node(tag_node, options, depth),
         HsmlNode::Comment(comment_node) if !comment_node.is_dev => {
-            Ok(compile_comment_node(comment_node, options))
+            Ok(compile_comment_node(comment_node, options, depth))
         }
         HsmlNode::Comment(_) => Ok(String::from("")),
         other => Err(format!("Unsupported root node type: {other:?}")),
@@ -133,7 +194,7 @@ pub fn compile(hsml_ast: &RootNode, options: &HsmlCompileOptions) -> Result<Stri
     let mut html_content = String::new();
 
     for node in &hsml_ast.nodes {
-        html_content.push_str(&compile_node(node, options)?);
+        html_content.push_str(&compile_node(node, options, 0)?);
     }
 
     Ok(html_content)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,14 @@ pub fn check_content(source: &str) -> Vec<diagnostic::Diagnostic> {
 pub fn compile_content_diagnostics(
     source: &str,
 ) -> Result<CompileOutput, Vec<diagnostic::Diagnostic>> {
+    compile_content_diagnostics_with_options(source, &compiler::HsmlCompileOptions::default())
+}
+
+/// Compile HSML source with custom options, returning structured diagnostics on error.
+pub fn compile_content_diagnostics_with_options(
+    source: &str,
+    options: &compiler::HsmlCompileOptions,
+) -> Result<CompileOutput, Vec<diagnostic::Diagnostic>> {
     let span = parser::Span::new(source);
 
     let (rest, ast) =
@@ -104,7 +112,7 @@ pub fn compile_content_diagnostics(
     // Run validation to collect warnings
     let diagnostics = validate::validate(&ast, source);
 
-    let html = compiler::compile(&ast, &compiler::HsmlCompileOptions::default())
+    let html = compiler::compile(&ast, options)
         .map_err(|e| vec![diagnostic::Diagnostic::compiler_error(e)])?;
 
     Ok(CompileOutput { html, diagnostics })
@@ -195,12 +203,53 @@ struct WasmCompileResult {
     diagnostics: Vec<diagnostic::Diagnostic>,
 }
 
+/// WASM compile options that deserializes from a JS object.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmCompileOptions {
+    #[serde(default)]
+    pretty: bool,
+    #[serde(default = "default_compile_indent_size")]
+    indent_size: usize,
+}
+
+fn default_compile_indent_size() -> usize {
+    compiler::HsmlCompileOptions::default().indent_size
+}
+
+impl From<WasmCompileOptions> for compiler::HsmlCompileOptions {
+    fn from(opts: WasmCompileOptions) -> Self {
+        Self {
+            pretty: opts.pretty,
+            indent_size: opts.indent_size,
+        }
+    }
+}
+
 /// Compile HSML source and return a JS object with HTML output and diagnostics.
 ///
 /// Returns a JS object: `{ success: boolean, html: string | null, diagnostics: Diagnostic[] }`
+///
+/// Options (all optional):
+/// - `pretty` — emit pretty-printed HTML with indentation (default: false)
+/// - `indentSize` — number of spaces per indentation level (default: 2)
 #[wasm_bindgen(js_name = "compileContentWithDiagnostics")]
-pub fn compile_content_with_diagnostics(source: &str) -> JsValue {
-    let result = match compile_content_diagnostics(source) {
+pub fn compile_content_with_diagnostics(source: &str, options: JsValue) -> JsValue {
+    let compile_options: compiler::HsmlCompileOptions =
+        if options.is_undefined() || options.is_null() {
+            compiler::HsmlCompileOptions::default()
+        } else {
+            let wasm_opts: WasmCompileOptions = match serde_wasm_bindgen::from_value(options) {
+                Ok(opts) => opts,
+                Err(_) => WasmCompileOptions {
+                    pretty: false,
+                    indent_size: default_compile_indent_size(),
+                },
+            };
+            wasm_opts.into()
+        };
+
+    let result = match compile_content_diagnostics_with_options(source, &compile_options) {
         Ok(output) => WasmCompileResult {
             success: true,
             html: Some(output.html),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -398,6 +398,60 @@ fn compile_debug_summary_shows_cross_for_errors() {
 }
 
 #[test]
+fn compile_pretty_produces_indented_html() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("test.hsml");
+    let output = dir.path().join("test.html");
+
+    fs::write(&input, "div\n  p Hello\n").unwrap();
+
+    cmd()
+        .args(["compile", "--pretty", input.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let html = fs::read_to_string(&output).unwrap();
+    assert_eq!(html, "<div>\n  <p>Hello</p>\n</div>\n");
+}
+
+#[test]
+fn compile_pretty_with_nested_structure() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("test.hsml");
+    let output = dir.path().join("test.html");
+
+    fs::write(&input, "doctype html\nhtml\n  head\n  body\n    p Hello\n").unwrap();
+
+    cmd()
+        .args(["compile", "--pretty", input.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let html = fs::read_to_string(&output).unwrap();
+    assert_eq!(
+        html,
+        "<!DOCTYPE html>\n<html>\n  <head></head>\n  <body>\n    <p>Hello</p>\n  </body>\n</html>\n"
+    );
+}
+
+#[test]
+fn compile_without_pretty_produces_single_line() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("test.hsml");
+    let output = dir.path().join("test.html");
+
+    fs::write(&input, "div\n  p Hello\n").unwrap();
+
+    cmd()
+        .args(["compile", input.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let html = fs::read_to_string(&output).unwrap();
+    assert_eq!(html, "<div><p>Hello</p></div>");
+}
+
+#[test]
 fn compile_json_emits_empty_array_for_clean_run() {
     let dir = TempDir::new().unwrap();
     let input = dir.path().join("clean.hsml");

--- a/tests/compiler.rs
+++ b/tests/compiler.rs
@@ -1,5 +1,6 @@
 use hsml::{
     check_content, compile_content_core, compile_content_diagnostics,
+    compile_content_diagnostics_with_options,
     compiler::{HsmlCompileOptions, compile},
     format_content_core,
     parser::{
@@ -590,4 +591,108 @@ fn format_content_returns_error_for_invalid_input() {
     let result = format_content_core("@@@invalid", &opts);
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("HSML parse error"));
+}
+
+// Pretty compilation tests
+
+#[test]
+fn compile_pretty_simple_nested() {
+    let opts = HsmlCompileOptions {
+        pretty: true,
+        ..Default::default()
+    };
+    let (_, ast) = parse(Span::new("div\n  p Hello\n")).unwrap();
+    assert_eq!(
+        compile(&ast, &opts).unwrap(),
+        "<div>\n  <p>Hello</p>\n</div>\n"
+    );
+}
+
+#[test]
+fn compile_pretty_deeply_nested() {
+    let opts = HsmlCompileOptions {
+        pretty: true,
+        ..Default::default()
+    };
+    let (_, ast) = parse(Span::new("div\n  section\n    p Hello\n")).unwrap();
+    assert_eq!(
+        compile(&ast, &opts).unwrap(),
+        "<div>\n  <section>\n    <p>Hello</p>\n  </section>\n</div>\n"
+    );
+}
+
+#[test]
+fn compile_pretty_void_elements() {
+    let opts = HsmlCompileOptions {
+        pretty: true,
+        ..Default::default()
+    };
+    let (_, ast) = parse(Span::new("div\n  br\n  hr\n")).unwrap();
+    assert_eq!(
+        compile(&ast, &opts).unwrap(),
+        "<div>\n  <br />\n  <hr />\n</div>\n"
+    );
+}
+
+#[test]
+fn compile_pretty_with_doctype() {
+    let opts = HsmlCompileOptions {
+        pretty: true,
+        ..Default::default()
+    };
+    let (_, ast) = parse(Span::new(
+        "doctype html\nhtml\n  head\n  body\n    p Hello\n",
+    ))
+    .unwrap();
+    assert_eq!(
+        compile(&ast, &opts).unwrap(),
+        "<!DOCTYPE html>\n<html>\n  <head></head>\n  <body>\n    <p>Hello</p>\n  </body>\n</html>\n"
+    );
+}
+
+#[test]
+fn compile_pretty_with_comments() {
+    let opts = HsmlCompileOptions {
+        pretty: true,
+        ..Default::default()
+    };
+    let (_, ast) = parse(Span::new("div\n  //! hello\n  p World\n")).unwrap();
+    assert_eq!(
+        compile(&ast, &opts).unwrap(),
+        "<div>\n  <!-- hello -->\n  <p>World</p>\n</div>\n"
+    );
+}
+
+#[test]
+fn compile_pretty_with_custom_indent() {
+    let opts = HsmlCompileOptions {
+        pretty: true,
+        indent_size: 4,
+    };
+    let (_, ast) = parse(Span::new("div\n  p Hello\n")).unwrap();
+    assert_eq!(
+        compile(&ast, &opts).unwrap(),
+        "<div>\n    <p>Hello</p>\n</div>\n"
+    );
+}
+
+#[test]
+fn compile_pretty_inline_text_no_extra_newline() {
+    let opts = HsmlCompileOptions {
+        pretty: true,
+        ..Default::default()
+    };
+    let (_, ast) = parse(Span::new("p Hello World\n")).unwrap();
+    assert_eq!(compile(&ast, &opts).unwrap(), "<p>Hello World</p>\n");
+}
+
+#[test]
+fn compile_pretty_via_diagnostics_api() {
+    let opts = HsmlCompileOptions {
+        pretty: true,
+        ..Default::default()
+    };
+    let output = compile_content_diagnostics_with_options("div\n  p Hello\n", &opts).unwrap();
+    assert_eq!(output.html, "<div>\n  <p>Hello</p>\n</div>\n");
+    assert!(output.diagnostics.is_empty());
 }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -17,7 +17,7 @@ fn wasm_compile_content_returns_error_for_invalid_input() {
 
 #[wasm_bindgen_test]
 fn wasm_compile_with_diagnostics_success() {
-    let result = hsml::compile_content_with_diagnostics("h1 Hello\n");
+    let result = hsml::compile_content_with_diagnostics("h1 Hello\n", JsValue::UNDEFINED);
 
     let success = js_sys::Reflect::get(&result, &JsValue::from_str("success")).unwrap();
     assert_eq!(success, JsValue::from_bool(true));
@@ -32,7 +32,7 @@ fn wasm_compile_with_diagnostics_success() {
 
 #[wasm_bindgen_test]
 fn wasm_compile_with_diagnostics_warning() {
-    let result = hsml::compile_content_with_diagnostics("h1.foo.foo Hello\n");
+    let result = hsml::compile_content_with_diagnostics("h1.foo.foo Hello\n", JsValue::UNDEFINED);
 
     let success = js_sys::Reflect::get(&result, &JsValue::from_str("success")).unwrap();
     assert_eq!(success, JsValue::from_bool(true));
@@ -51,7 +51,7 @@ fn wasm_compile_with_diagnostics_warning() {
 
 #[wasm_bindgen_test]
 fn wasm_compile_with_diagnostics_error() {
-    let result = hsml::compile_content_with_diagnostics("@@@invalid");
+    let result = hsml::compile_content_with_diagnostics("@@@invalid", JsValue::UNDEFINED);
 
     let success = js_sys::Reflect::get(&result, &JsValue::from_str("success")).unwrap();
     assert_eq!(success, JsValue::from_bool(false));
@@ -66,6 +66,17 @@ fn wasm_compile_with_diagnostics_error() {
     let diag = arr.get(0);
     let severity = js_sys::Reflect::get(&diag, &JsValue::from_str("severity")).unwrap();
     assert_eq!(severity, JsValue::from_str("error"));
+}
+
+#[wasm_bindgen_test]
+fn wasm_compile_with_diagnostics_pretty() {
+    let options = js_sys::Object::new();
+    js_sys::Reflect::set(&options, &JsValue::from_str("pretty"), &JsValue::from(true)).unwrap();
+
+    let result = hsml::compile_content_with_diagnostics("div\n  p Hello\n", options.into());
+
+    let html = js_sys::Reflect::get(&result, &JsValue::from_str("html")).unwrap();
+    assert_eq!(html, JsValue::from_str("<div>\n  <p>Hello</p>\n</div>\n"));
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--pretty` flag to format compiled HTML with indentation and newlines
  * Added support for customizable indentation width in compilation options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->