### PR TITLE
fix: merge shorthand and attribute class values

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -44,24 +44,36 @@ fn compile_tag_node(
         html_content.push('\"');
     }
 
+    // Collect shorthand classes
+    let mut all_classes: Vec<&str> = Vec::new();
     if let Some(class_nodes) = &tag_node.classes {
+        all_classes.extend(class_nodes.iter().map(|c| c.name.as_str()));
+    }
+
+    // Merge class attributes from (class="...") with shorthand classes
+    if let Some(attributes) = &tag_node.attributes {
+        for node in attributes {
+            if let HsmlNode::Attribute(AttributeNode { key, value, .. }) = node
+                && key == "class"
+                && let Some(value) = value
+            {
+                all_classes.extend(value.split_whitespace());
+            }
+        }
+    }
+
+    // Write merged class attribute
+    if !all_classes.is_empty() {
         html_content.push_str(r#" class=""#);
-
-        let class_names: String = class_nodes
-            .iter()
-            .map(|class_node| class_node.name.as_str())
-            .collect::<Vec<&str>>()
-            .join(" ");
-
-        html_content.push_str(&class_names);
-
+        html_content.push_str(&all_classes.join(" "));
         html_content.push('\"');
     }
 
+    // Write remaining attributes (skip class — already merged)
     if let Some(attributes) = &tag_node.attributes {
         for node in attributes {
             match node {
-                HsmlNode::Attribute(AttributeNode { key, value, .. }) => {
+                HsmlNode::Attribute(AttributeNode { key, value, .. }) if key != "class" => {
                     html_content.push(' ');
                     html_content.push_str(key);
 
@@ -70,6 +82,9 @@ fn compile_tag_node(
                         html_content.push_str(value);
                         html_content.push('\"');
                     }
+                }
+                HsmlNode::Attribute(AttributeNode { key, .. }) if key == "class" => {
+                    // Already merged above
                 }
                 HsmlNode::Comment(node) if node.is_dev => {
                     // do nothing

--- a/tests/compiler.rs
+++ b/tests/compiler.rs
@@ -241,6 +241,70 @@ fn it_should_not_self_close_custom_components() {
     );
 }
 
+// Class attribute merging
+
+#[test]
+fn it_should_merge_shorthand_and_attribute_classes() {
+    assert_eq!(
+        compile_content_core("div.foo(class=\"bar\") Hello\n"),
+        Ok(String::from(r#"<div class="foo bar">Hello</div>"#))
+    );
+}
+
+#[test]
+fn it_should_merge_multiple_shorthand_with_attribute_classes() {
+    assert_eq!(
+        compile_content_core("div.a.b(class=\"c d\") Hello\n"),
+        Ok(String::from(r#"<div class="a b c d">Hello</div>"#))
+    );
+}
+
+#[test]
+fn it_should_handle_class_attribute_without_shorthand() {
+    assert_eq!(
+        compile_content_core("div(class=\"foo bar\") Hello\n"),
+        Ok(String::from(r#"<div class="foo bar">Hello</div>"#))
+    );
+}
+
+#[test]
+fn it_should_handle_shorthand_classes_without_attribute() {
+    assert_eq!(
+        compile_content_core("div.foo.bar Hello\n"),
+        Ok(String::from(r#"<div class="foo bar">Hello</div>"#))
+    );
+}
+
+#[test]
+fn it_should_preserve_other_attributes_when_merging_classes() {
+    assert_eq!(
+        compile_content_core("div.foo(class=\"bar\" data-x=\"1\") Hello\n"),
+        Ok(String::from(
+            r#"<div class="foo bar" data-x="1">Hello</div>"#
+        ))
+    );
+}
+
+#[test]
+fn it_should_merge_classes_with_shorthand_id() {
+    assert_eq!(
+        compile_content_core("div#app.foo(class=\"bar\") Hello\n"),
+        Ok(String::from(r#"<div id="app" class="foo bar">Hello</div>"#))
+    );
+}
+
+#[test]
+fn it_should_merge_classes_and_preserve_framework_bindings() {
+    assert_eq!(
+        compile_content_core(
+            "div.card(class=\"active\" :class=\"dynamicClass\" [class]=\"expr\")\n"
+        ),
+        Ok(String::from(
+            r#"<div class="card active" :class="dynamicClass" [class]="expr"></div>"#
+        ))
+    );
+}
+
 // Tests for compile_content error handling (mirrors lib.rs WASM logic)
 
 #[test]

--- a/tests/compiler.rs
+++ b/tests/compiler.rs
@@ -305,6 +305,24 @@ fn it_should_merge_classes_and_preserve_framework_bindings() {
     );
 }
 
+#[test]
+fn it_should_handle_valueless_class_with_shorthand() {
+    // div.foo(class) — valueless class is a no-op, shorthand still works
+    assert_eq!(
+        compile_content_core("div.foo(class) Hello\n"),
+        Ok(String::from(r#"<div class="foo">Hello</div>"#))
+    );
+}
+
+#[test]
+fn it_should_drop_valueless_class_without_shorthand() {
+    // div(class) — valueless class with no shorthand produces no class attribute
+    assert_eq!(
+        compile_content_core("div(class) Hello\n"),
+        Ok(String::from("<div>Hello</div>"))
+    );
+}
+
 // Tests for compile_content error handling (mirrors lib.rs WASM logic)
 
 #[test]

--- a/tests/compiler.rs
+++ b/tests/compiler.rs
@@ -323,6 +323,18 @@ fn it_should_drop_valueless_class_without_shorthand() {
     );
 }
 
+#[test]
+fn it_should_ignore_whitespace_only_class_attribute_values() {
+    assert_eq!(
+        compile_content_core("div.foo(class=\"   \") Hello\n"),
+        Ok(String::from(r#"<div class="foo">Hello</div>"#))
+    );
+    assert_eq!(
+        compile_content_core("div(class=\"   \") Hello\n"),
+        Ok(String::from("<div>Hello</div>"))
+    );
+}
+
 // Tests for compile_content error handling (mirrors lib.rs WASM logic)
 
 #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSS class handling: shorthand classes and explicit class attributes are now merged into a single emitted class attribute to avoid duplicates and ensure correct styling.
* **Tests**
  * Added test coverage for class-merge behavior, including shorthand+attribute combinations, valueless class cases, id+class interactions, and preservation of non-class bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->