### PR TITLE
fix: expand self-closing non-void tags in converter

### DIFF
--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -30,13 +30,14 @@ fn expand_self_closing_tags(html: &str) -> String {
 
     while i < bytes.len() {
         // Skip HTML comments
-        if bytes[i] == b'<' && html[i..].starts_with("<!--") {
-            if let Some(end) = html[i + 4..].find("-->") {
-                let comment_end = i + 4 + end + 3;
-                result.push_str(&html[i..comment_end]);
-                i = comment_end;
-                continue;
-            }
+        if bytes[i] == b'<'
+            && html[i..].starts_with("<!--")
+            && let Some(end) = html[i + 4..].find("-->")
+        {
+            let comment_end = i + 4 + end + 3;
+            result.push_str(&html[i..comment_end]);
+            i = comment_end;
+            continue;
         }
 
         // Check for start of an opening tag

--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -89,9 +89,12 @@ fn expand_self_closing_tags(html: &str) -> String {
                             i = j + 1;
                             found_end = true;
 
-                            // Skip raw text content inside script/style tags
+                            // Skip raw text content inside raw text / RCDATA elements
                             let tag_lower = tag_name.to_ascii_lowercase();
-                            if tag_lower == "script" || tag_lower == "style" {
+                            if matches!(
+                                tag_lower.as_str(),
+                                "script" | "style" | "textarea" | "title"
+                            ) {
                                 let closing = format!("</{tag_name}>");
                                 let closing_lower = closing.to_ascii_lowercase();
                                 if let Some(pos) =

--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -4,14 +4,112 @@ use html5ever::parse_document;
 use html5ever::tendril::TendrilSink;
 use markup5ever_rcdom::RcDom;
 
+use crate::common::is_void_element;
+
 /// Convert an HTML string to HSML source.
 pub fn convert(html: &str) -> Result<String, String> {
+    let preprocessed = expand_self_closing_tags(html);
     let dom = parse_document(RcDom::default(), Default::default())
         .from_utf8()
-        .read_from(&mut html.as_bytes())
+        .read_from(&mut preprocessed.as_bytes())
         .map_err(|e| format!("HTML parse error: {e}"))?;
 
-    Ok(emitter::emit(&dom, html))
+    Ok(emitter::emit(&dom, &preprocessed))
+}
+
+/// Expand self-closing non-void elements (e.g. `<div />` → `<div></div>`).
+///
+/// HTML5 only allows void elements to be self-closing. html5ever follows the
+/// spec and treats `<div />` as an opening `<div>` tag, which swallows all
+/// subsequent siblings as children. This pre-processing step fixes that by
+/// expanding such tags into proper open/close pairs before parsing.
+fn expand_self_closing_tags(html: &str) -> String {
+    let mut result = String::with_capacity(html.len());
+    let bytes = html.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        // Skip HTML comments
+        if bytes[i] == b'<' && html[i..].starts_with("<!--") {
+            if let Some(end) = html[i + 4..].find("-->") {
+                let comment_end = i + 4 + end + 3;
+                result.push_str(&html[i..comment_end]);
+                i = comment_end;
+                continue;
+            }
+        }
+
+        // Check for start of an opening tag
+        if bytes[i] == b'<'
+            && i + 1 < bytes.len()
+            && (bytes[i + 1].is_ascii_alphabetic() || bytes[i + 1] == b'_')
+        {
+            let tag_start = i + 1;
+            let mut j = tag_start;
+            while j < bytes.len()
+                && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'-' || bytes[j] == b'_')
+            {
+                j += 1;
+            }
+            let tag_name = &html[tag_start..j];
+
+            // Scan through attributes to find > or />
+            let mut in_quote = false;
+            let mut quote_char = b'"';
+            let mut found_end = false;
+            while j < bytes.len() {
+                if in_quote {
+                    if bytes[j] == quote_char {
+                        in_quote = false;
+                    }
+                } else {
+                    match bytes[j] {
+                        b'"' | b'\'' => {
+                            in_quote = true;
+                            quote_char = bytes[j];
+                        }
+                        b'/' if j + 1 < bytes.len() && bytes[j + 1] == b'>' => {
+                            if !is_void_element(tag_name) {
+                                // Non-void: <tag .../>  →  <tag ...></tag>
+                                result.push_str(&html[i..j]);
+                                result.push_str("></");
+                                result.push_str(tag_name);
+                                result.push('>');
+                            } else {
+                                // Void element: keep as-is
+                                result.push_str(&html[i..j + 2]);
+                            }
+                            i = j + 2;
+                            found_end = true;
+                            break;
+                        }
+                        b'>' => {
+                            result.push_str(&html[i..j + 1]);
+                            i = j + 1;
+                            found_end = true;
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+                j += 1;
+            }
+            if !found_end {
+                result.push_str(&html[i..]);
+                break;
+            }
+        } else {
+            // Copy everything up to the next '<' in bulk
+            let start = i;
+            i += 1;
+            while i < bytes.len() && bytes[i] != b'<' {
+                i += 1;
+            }
+            result.push_str(&html[start..i]);
+        }
+    }
+
+    result
 }
 
 #[cfg(test)]

--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -87,6 +87,21 @@ fn expand_self_closing_tags(html: &str) -> String {
                             result.push_str(&html[i..j + 1]);
                             i = j + 1;
                             found_end = true;
+
+                            // Skip raw text content inside script/style tags
+                            let tag_lower = tag_name.to_ascii_lowercase();
+                            if tag_lower == "script" || tag_lower == "style" {
+                                let closing = format!("</{tag_name}>");
+                                let closing_lower = closing.to_ascii_lowercase();
+                                if let Some(pos) =
+                                    html[i..].to_ascii_lowercase().find(&closing_lower)
+                                {
+                                    let end = i + pos + closing.len();
+                                    result.push_str(&html[i..end]);
+                                    i = end;
+                                }
+                            }
+
                             break;
                         }
                         _ => {}

--- a/src/converter/tests/convert.rs
+++ b/src/converter/tests/convert.rs
@@ -457,6 +457,122 @@ fn it_should_not_escape_script_in_mixed_content() {
     );
 }
 
+// --- Self-closing non-void elements ---
+
+#[test]
+fn it_should_handle_self_closing_non_void_element() {
+    // <div /> is not valid self-closing HTML (div is not a void element),
+    // but frameworks like Vue use it commonly. html5ever treats <div /> as <div>
+    // which swallows all subsequent siblings as children.
+    assert_eq!(
+        conv(r#"<div class="parent"><div class="child" /><div class="sibling">Hello</div></div>"#),
+        ".parent\n  .child\n  .sibling Hello\n"
+    );
+}
+
+#[test]
+fn it_should_handle_self_closing_span() {
+    assert_eq!(
+        conv(r#"<div><span class="icon" /><span>Text</span></div>"#),
+        "div\n  span.icon\n  span Text\n"
+    );
+}
+
+#[test]
+fn it_should_keep_void_elements_self_closing() {
+    // img is a void element — self-closing is fine and should still work
+    assert_eq!(
+        conv(r#"<div><img src="a.jpg" /><p>Text</p></div>"#),
+        "div\n  img(src=\"a.jpg\")\n  p Text\n"
+    );
+}
+
+#[test]
+fn it_should_keep_br_self_closing() {
+    assert_eq!(
+        conv(r#"<div><br /><p>Text</p></div>"#),
+        "div\n  br\n  p Text\n"
+    );
+}
+
+#[test]
+fn it_should_handle_self_closing_with_attributes() {
+    assert_eq!(
+        conv(r#"<div class="a" data-x="y" />"#),
+        ".a(data-x=\"y\")\n"
+    );
+}
+
+#[test]
+fn it_should_handle_self_closing_pascal_case_component() {
+    assert_eq!(
+        conv(r#"<div><MyComponent class="active" /><p>After</p></div>"#),
+        "div\n  MyComponent.active\n  p After\n"
+    );
+}
+
+#[test]
+fn it_should_handle_multiple_self_closing_siblings() {
+    assert_eq!(
+        conv(r#"<div><div class="a" /><div class="b" /><div class="c" /></div>"#),
+        "div\n  .a\n  .b\n  .c\n"
+    );
+}
+
+#[test]
+fn it_should_handle_self_closing_in_comment_context() {
+    // Self-closing divs inside comments should not be expanded
+    assert_eq!(
+        conv(r#"<!-- <div class="ignore" /> --><p>Hello</p>"#),
+        "//! <div class=\"ignore\" />\np Hello\n"
+    );
+}
+
+#[test]
+fn it_should_handle_elk_skeleton_html() {
+    let html = r#"<div>
+  <div px2 pt2>
+    <div rounded of-hidden aspect="3.19" class="flex skeleton-loading-bg" />
+    <div px-4 pb-4 flex="~ col gap-2">
+      <div flex sm:flex-row flex-col flex-gap-2>
+        <div flex items-center justify-between>
+          <div w-17 h-17 rounded-full border-4 border-bg-base z-2 mt--2 ms--1 of-hidden bg-base>
+            <div class="flex skeleton-loading-bg" w-full h-full />
+          </div>
+          <div block sm:hidden class="skeleton-loading-bg" h-8 w-30 rounded-full />
+        </div>
+        <div sm:mt-2 flex="~ col 1 gap-2">
+          <div flex class="skeleton-loading-bg" h-5 w-20 rounded />
+          <div flex class="skeleton-loading-bg" h-4 w-40 rounded />
+        </div>
+      </div>
+      <div flex class="skeleton-loading-bg" h-4 my3 w="3/5" rounded />
+      <div flex justify-between items-center>
+        <div flex class="skeleton-loading-bg" h-4 w="sm:1/2 full" rounded />
+        <div sm:flex hidden class="skeleton-loading-bg" h-8 w-30 rounded-full />
+      </div>
+    </div>
+  </div>
+</div>"#;
+
+    let result = conv(html);
+
+    // Each self-closing div should be a sibling, not swallowing subsequent elements.
+    // The skeleton-loading-bg divs that are self-closing should not nest their siblings.
+    // Verify key structural properties:
+    // 1. "px-4" div should be a sibling of the first skeleton-loading-bg, not a child
+    assert!(
+        !result.contains("      .flex.skeleton-loading-bg\n        div"),
+        "self-closing div should not swallow siblings as children"
+    );
+    // 2. The result should have the right number of skeleton-loading-bg occurrences
+    assert_eq!(
+        result.matches("skeleton-loading-bg").count(),
+        8,
+        "all 8 skeleton-loading-bg elements should be present"
+    );
+}
+
 // --- TailwindCSS ---
 
 #[test]

--- a/src/converter/tests/convert.rs
+++ b/src/converter/tests/convert.rs
@@ -545,6 +545,22 @@ fn it_should_not_expand_self_closing_tags_inside_style() {
 }
 
 #[test]
+fn it_should_not_expand_self_closing_tags_inside_textarea() {
+    assert_eq!(
+        conv(r#"<textarea><div /></textarea><p>Hello</p>"#),
+        "textarea.\n  <div />\np Hello\n"
+    );
+}
+
+#[test]
+fn it_should_not_expand_self_closing_tags_inside_title() {
+    assert_eq!(
+        conv(r#"<title><div /></title><p>Hello</p>"#),
+        "title <div />\np Hello\n"
+    );
+}
+
+#[test]
 fn it_should_handle_elk_skeleton_html() {
     let html = r#"<div>
   <div px2 pt2>

--- a/src/converter/tests/convert.rs
+++ b/src/converter/tests/convert.rs
@@ -529,6 +529,22 @@ fn it_should_handle_self_closing_in_comment_context() {
 }
 
 #[test]
+fn it_should_not_expand_self_closing_tags_inside_script() {
+    assert_eq!(
+        conv(r#"<script>var x = '<div />';</script><p>Hello</p>"#),
+        "script.\n  var x = '<div />';\np Hello\n"
+    );
+}
+
+#[test]
+fn it_should_not_expand_self_closing_tags_inside_style() {
+    assert_eq!(
+        conv(r#"<style>div::before { content: '<div />'; }</style><p>Hello</p>"#),
+        "style.\n  div::before { content: '<div />'; }\np Hello\n"
+    );
+}
+
+#[test]
 fn it_should_handle_elk_skeleton_html() {
     let html = r#"<div>
   <div px2 pt2>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of self-closing non-void elements so they expand to normal open/close tags; void elements remain self-closed.
  * Treat HTML comments as opaque and avoid expanding self-closing syntax inside raw-text sections (script/style/textarea/title).

* **Tests**
  * Added comprehensive unit and end-to-end tests covering self-closing behavior, comment/raw-text edge cases, attribute preservation, and structural sibling containment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->